### PR TITLE
Add logging to scorecard ingestion and cleaning

### DIFF
--- a/src/ira/clean/clean_scorecard.py
+++ b/src/ira/clean/clean_scorecard.py
@@ -1,8 +1,14 @@
 import pandas as pd
 import numpy as np
-import time
+
+from ira.logging_utils import get_logger
+
+
+logger = get_logger(__name__)
 
 def clean (df: pd.DataFrame) -> pd.DataFrame:
+    original_shape = df.shape
+    logger.info("Starting clean() with shape=%s", original_shape)
 
     #----------------------------------------- Standardizing column names
     df.columns = df.columns.str.replace(".", "_")
@@ -47,12 +53,28 @@ def clean (df: pd.DataFrame) -> pd.DataFrame:
         )
     # ----------------------------------------- Numeric cleanup
     numeric_cols = df.select_dtypes(include="number").columns
-    print(f"Numeric columns: {numeric_cols}")
+    logger.info("Applying numeric cleanup to %s numeric columns", len(numeric_cols))
     df[numeric_cols] = df[numeric_cols].mask(df[numeric_cols] < 0, np.nan)
 
     #----------------------------------------- De-duplicating rows
-    if df.duplicated().sum():
-        print(f"{df.duplicated().sum()} duplicated rows found.\n{df[df.duplicated()==True]}")
-        # df = df.drop_duplicates()
+    duplicate_count = int(df.duplicated().sum())
+    if duplicate_count:
+        logger.warning("Removing %s duplicated rows", duplicate_count)
+        df = df.drop_duplicates()
+
+    missing_counts = df.isna().sum()
+    missing_counts = missing_counts[missing_counts > 0].sort_values(ascending=False)
+    if not missing_counts.empty:
+        top_missing = ", ".join(
+            f"{column}={count}" for column, count in missing_counts.head(5).items()
+        )
+        logger.warning(
+            "Missing values remain in %s columns after cleaning; top columns: %s",
+            len(missing_counts),
+            top_missing,
+        )
+
+    logger.info("Completed clean() with shape=%s", df.shape)
+    logger.info("Cleaning shape summary: %s -> %s", original_shape, df.shape)
 
     return df

--- a/src/ira/ingest/ingest_scorecard.py
+++ b/src/ira/ingest/ingest_scorecard.py
@@ -1,15 +1,58 @@
 # ingest_scorecard.py
 
-import requests
-import pandas as pd
-from pathlib import Path
-from ira.config import SCORECARD_KEY, BASE_URL
+import json
 import math
-import time
 import random
+import time
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import pandas as pd
+import requests
+
+from ira.config import BASE_URL, SCORECARD_KEY
+from ira.logging_utils import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def redact_url(value: str) -> str:
+    if not value:
+        return value
+
+    parts = urlsplit(value)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    if not query:
+        return value
+
+    redacted_query = []
+    for key, query_value in query:
+        key_lower = key.lower()
+        if key_lower == "api_key" or key_lower.endswith("_key"):
+            redacted_query.append((key, "***REDACTED***"))
+        else:
+            redacted_query.append((key, query_value))
+
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(redacted_query, doseq=True),
+            parts.fragment,
+        )
+    )
+
+
+def build_request_url(url: str, params: dict) -> str:
+    prepared = requests.Request("GET", url, params=params).prepare()
+    return redact_url(prepared.url)
 
 
 def collect(state: str = "FL", per_page: int = 100) -> pd.DataFrame:
+    logger.info("Starting College Scorecard collection for state=%s with per_page=%s", state, per_page)
+
     fields = ",".join([
         "id",
         "school.name",
@@ -44,6 +87,8 @@ def collect(state: str = "FL", per_page: int = 100) -> pd.DataFrame:
     }
 
     dfs = []
+    total_api_rows = 0
+    total_filtered_rows = 0
 
     params["page"] = "0"
     response = get_with_retries(BASE_URL, params=params, timeout=30)
@@ -52,6 +97,7 @@ def collect(state: str = "FL", per_page: int = 100) -> pd.DataFrame:
     total = int(data["metadata"]["total"])
     per_page_actual = int(data["metadata"]["per_page"])
     total_pages = math.ceil(total / per_page_actual)
+    logger.info("API reports %s total rows across %s pages", total, total_pages)
 
     META = [
         "id",
@@ -66,30 +112,49 @@ def collect(state: str = "FL", per_page: int = 100) -> pd.DataFrame:
         "latest.school.title_iv.eligibility_type",
     ]
 
-    def page_to_df(data):
-        results = [r for r in data.get("results", []) if r.get("latest.programs.cip_4_digit")]
-        return pd.json_normalize(
+    def page_to_df(data, page_number: int):
+        nonlocal total_api_rows, total_filtered_rows
+
+        raw_results = data.get("results", [])
+        total_api_rows += len(raw_results)
+
+        results = [r for r in raw_results if r.get("latest.programs.cip_4_digit")]
+        total_filtered_rows += len(results)
+
+        page_df = pd.json_normalize(
             results,
             record_path=["latest.programs.cip_4_digit"],
             meta=META,
             errors="ignore",
         )
+        logger.info(
+            "Fetched page %s/%s: %s raw rows, %s kept rows, %s program rows",
+            page_number + 1,
+            total_pages,
+            len(raw_results),
+            len(results),
+            len(page_df),
+        )
+        return page_df
 
-    dfs.append(page_to_df(data))
+    dfs.append(page_to_df(data, 0))
 
     for page in range(1, total_pages):
         params["page"] = str(page)
         response = get_with_retries(BASE_URL, params=params, timeout=30)
         data = get_json_or_raise(response)
-        dfs.append(page_to_df(data))
+        dfs.append(page_to_df(data, page))
 
     df = pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
-
-    print(f"Total pages fetched: {total_pages}")
-    print(f"Total Rows/Programs ingested: {len(df)}")
+    logger.info("Total rows collected before filtering: %s", total_api_rows)
+    logger.info("Total rows after filtering: %s", total_filtered_rows)
+    logger.info("Total program rows ingested: %s", len(df))
     return df
 
+
 def get_json_or_raise(response: requests.Response):
+    response_url = redact_url(response.url)
+
     # Raise for HTTP errors early (4xx/5xx)
     try:
         response.raise_for_status()
@@ -97,7 +162,7 @@ def get_json_or_raise(response: requests.Response):
         ct = response.headers.get("Content-Type", "")
         body_preview = (response.text or "")[:800]
         raise RuntimeError(
-            f"HTTP {response.status_code} for {response.url}\n"
+            f"HTTP {response.status_code} for {response_url}\n"
             f"Content-Type: {ct}\n"
             f"Body preview:\n{body_preview}"
         ) from e
@@ -108,7 +173,7 @@ def get_json_or_raise(response: requests.Response):
         body_preview = (response.text or "")[:800]
         raise RuntimeError(
             f"Expected JSON but got Content-Type: {ct}\n"
-            f"URL: {response.url}\n"
+            f"URL: {response_url}\n"
             f"Body preview:\n{body_preview}"
         )
 
@@ -118,20 +183,48 @@ def get_json_or_raise(response: requests.Response):
     except json.JSONDecodeError as e:
         body_preview = (response.text or "")[:800]
         raise RuntimeError(
-            f"JSON decode failed for {response.url}\n"
+            f"JSON decode failed for {response_url}\n"
             f"Body preview:\n{body_preview}"
         ) from e
-    
+
 
 def get_with_retries(url, params, tries=5, timeout=30):
     last = None
+    safe_url = build_request_url(url, params)
     for i in range(tries):
-        r = requests.get(url, params=params, timeout=timeout, headers={"Accept": "application/json"})
+        try:
+            r = requests.get(url, params=params, timeout=timeout, headers={"Accept": "application/json"})
+        except requests.RequestException as exc:
+            logger.warning(
+                "Request attempt %s/%s failed for %s: %s",
+                i + 1,
+                tries,
+                safe_url,
+                exc.__class__.__name__,
+            )
+            if i == tries - 1:
+                raise RuntimeError(
+                    f"Request failed after {tries} attempts for {safe_url}: {exc.__class__.__name__}"
+                ) from exc
+            time.sleep((2 ** i) + random.random())
+            continue
+
         if r.status_code < 500:
             return r
         last = r
+        logger.warning(
+            "Server error on attempt %s/%s for %s: HTTP %s",
+            i + 1,
+            tries,
+            redact_url(r.url),
+            r.status_code,
+        )
         time.sleep((2 ** i) + random.random())
+
+    if last is not None:
+        logger.error("Exhausted retries for %s after %s attempts", redact_url(last.url), tries)
     return last
+
 
 def save(df: pd.DataFrame, file_type: str="raw", file_name: str = "scorecard_FL_programs.csv") -> None :
     root = Path(__file__).resolve().parents[3]

--- a/src/ira/logging_utils.py
+++ b/src/ira/logging_utils.py
@@ -1,0 +1,15 @@
+import logging
+
+
+LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+
+
+def get_logger(name: str) -> logging.Logger:
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+
+    logger = logging.getLogger(name)
+    if logger.level == logging.NOTSET:
+        logger.setLevel(logging.INFO)
+    return logger


### PR DESCRIPTION
## Summary of Changes
This PR changes the Scorecard ingestion and cleaning files to use logging instead of `print()`. It adds clearer progress messages, warnings for duplicates and missing values, and makes sure the API key does not show up in logged URLs.

---

## Linked Issue
Closes #22

---

## What Was Done
- Added a small shared logging helper
- Replaced `print()` messages in `ingest_scorecard.py` with logging
- Added logs for collection start, pages fetched, and total row counts
- Replaced `print()` messages in `clean_scorecard.py` with logging
- Added logs for shape before/after cleaning, duplicate rows, and missing values
- Added API key redaction for logged URLs
- Made duplicate rows get removed instead of only being printed

---

## Validation / Testing
How was this verified?
- [x] Notebook runs start to finish
- [x] Script executes without errors
- [x] No broken imports
- [x] Outputs reproducible

I tested `collect("FL")` and `clean(df)` and confirmed the new logging shows up clearly without exposing the API key.