### PR TITLE
Split individual and batch predictions into separate pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,12 @@ streamlit run src/ira/streamlit_app.py
 
 The dashboard supports:
 
-- program search
+- a home dashboard for statewide comparisons
+- an individual prediction page with a single-record form
+- a saved Florida program explorer
 - side-by-side comparison of predicted and reported earnings
 - 1-, 4-, and 5-year earnings view
-- batch CSV upload for predictions
+- a separate batch CSV prediction page
 
 ## Tests
 
@@ -199,6 +201,7 @@ pip install -e .[dev]
 |-- src/
 |   `-- ira/
 |       |-- api.py
+|       |-- pages/
 |       |-- stability.py
 |       |-- streamlit_app.py
 |       `-- modeling/

--- a/src/ira/pages/1_Individual_Predictions.py
+++ b/src/ira/pages/1_Individual_Predictions.py
@@ -1,0 +1,721 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+import streamlit as st
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ira.streamlit_app import (
+    FEATURE_LABELS,
+    PRIMARY_ACTUAL_COLUMN,
+    PRIMARY_PREDICTION_COLUMN,
+    build_program_comparison_chart,
+    configure_page,
+    filter_programs,
+    format_currency,
+    format_credential_level,
+    format_feature_value,
+    format_signed_currency,
+    get_choice_label,
+    load_app_state,
+    normalize_code_label,
+    normalize_form_value,
+    render_hero,
+    render_metric_cards,
+    render_sidebar,
+    shorten_text,
+    stability_badge,
+    status_badge,
+    TARGET_COLUMNS,
+    YEAR_LABELS,
+)
+
+
+def build_program_option_label(row: pd.Series) -> str:
+    actual_text = format_currency(row.get(PRIMARY_ACTUAL_COLUMN, row.get("4_yr_median_earnings")))
+    gap_text = format_signed_currency(row.get("gap"))
+    return (
+        f"{row['code']} | "
+        f"{shorten_text(row['title'], 50)} | "
+        f"{shorten_text(row['school_name'], 30)} | "
+        f"Actual: {actual_text} | Gap: {gap_text}"
+    )
+
+
+def build_results_table(frame: pd.DataFrame, max_rows: int = 12) -> pd.DataFrame:
+    preview = frame.copy()
+    if "match_score" in preview.columns:
+        preview = preview.head(max_rows)
+    else:
+        preview["sort_gap"] = preview["gap"].abs().fillna(-1)
+        preview = preview.sort_values(["sort_gap", "title"], ascending=[False, True]).head(max_rows)
+    return pd.DataFrame(
+        {
+            "CIP": preview["code"],
+            "Program": preview["title"],
+            "School": preview["school_name"],
+            "Actual": preview[PRIMARY_ACTUAL_COLUMN].map(format_currency),
+            "Predicted": preview[PRIMARY_PREDICTION_COLUMN].map(format_currency),
+            "Gap vs expected": preview["gap"].map(format_signed_currency),
+            "Compared with expected": preview["performance"],
+            "Multi-year pattern": preview["stability_status"],
+        }
+    )
+
+
+def build_feature_table(selected_row: pd.Series, feature_columns: list[str]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Feature": [FEATURE_LABELS.get(column, column) for column in feature_columns],
+            "Value": [format_feature_value(column, selected_row.get(column)) for column in feature_columns],
+        }
+    )
+
+
+def build_prediction_only_table(selected_row: pd.Series, predictor) -> pd.DataFrame:
+    rows: list[dict[str, str]] = []
+    for year in predictor.years:
+        predicted = selected_row.get(predictor.prediction_columns_by_year[year])
+        rows.append(
+            {
+                "Time after completion": YEAR_LABELS[year],
+                "Estimated earnings": format_currency(predicted),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def closest_numeric_option_index(options: list[dict[str, object]], default_value: float) -> int:
+    if not options:
+        return 0
+    return min(
+        range(len(options)),
+        key=lambda index: abs(float(options[index]["value"]) - float(default_value)),
+    )
+
+
+def option_index_by_value(options: list[dict[str, object]], default_value: object) -> int:
+    for index, option in enumerate(options):
+        if option["value"] == default_value:
+            return index
+    return 0
+
+
+def build_profile_choice_options(programs: pd.DataFrame) -> dict[str, list[dict[str, object]]]:
+    admission = programs["admission_rate_overall"].dropna()
+    pell = programs["students_with_pell_grant"].dropna()
+    family_income = programs["median_family_income"].dropna()
+
+    admission_quantiles = admission.quantile([0.2, 0.5, 0.8]).to_dict()
+    pell_quantiles = pell.quantile([0.2, 0.5, 0.8]).to_dict()
+    income_quantiles = family_income.quantile([0.2, 0.5, 0.8]).to_dict()
+
+    return {
+        "selectivity_bucket": [
+            {"label": "Easier to get into", "value": "open"},
+            {"label": "Somewhat selective", "value": "mid"},
+            {"label": "More selective", "value": "elite"},
+        ],
+        "admission_rate_overall": [
+            {"label": f"Lower admit rate | {admission_quantiles[0.2]:.0%}", "value": float(admission_quantiles[0.2])},
+            {"label": f"Typical | {admission_quantiles[0.5]:.0%}", "value": float(admission_quantiles[0.5])},
+            {"label": f"Higher admit rate | {admission_quantiles[0.8]:.0%}", "value": float(admission_quantiles[0.8])},
+        ],
+        "students_with_pell_grant": [
+            {"label": f"Lower Pell share | {pell_quantiles[0.2]:.0%}", "value": float(pell_quantiles[0.2])},
+            {"label": f"Typical | {pell_quantiles[0.5]:.0%}", "value": float(pell_quantiles[0.5])},
+            {"label": f"Higher Pell share | {pell_quantiles[0.8]:.0%}", "value": float(pell_quantiles[0.8])},
+        ],
+        "median_family_income": [
+            {"label": f"Lower family income | {format_currency(income_quantiles[0.2])}", "value": float(income_quantiles[0.2])},
+            {"label": f"Typical | {format_currency(income_quantiles[0.5])}", "value": float(income_quantiles[0.5])},
+            {"label": f"Higher family income | {format_currency(income_quantiles[0.8])}", "value": float(income_quantiles[0.8])},
+        ],
+    }
+
+
+def build_cip_reference(programs: pd.DataFrame) -> pd.DataFrame:
+    def first_common_title(series: pd.Series) -> str:
+        clean = series.dropna().astype(str).str.strip()
+        if clean.empty:
+            return "Unknown program area"
+        modes = clean.mode()
+        if not modes.empty:
+            return str(modes.iat[0])
+        return str(clean.iat[0])
+
+    cip_reference = (
+        programs.assign(code=programs["code"].astype(str).str.extract(r"(\d+)", expand=False).str.zfill(4))
+        .dropna(subset=["code"])
+        .groupby("code", as_index=False)
+        .agg(
+            sample_title=("title", first_common_title),
+            school_count=("school_name", "nunique"),
+            program_count=("title", "size"),
+        )
+    )
+    cip_reference["option_label"] = (
+        cip_reference["sample_title"].map(lambda value: shorten_text(value, 68))
+        + " | CIP "
+        + cip_reference["code"]
+    )
+    return cip_reference.sort_values(["sample_title", "code"]).reset_index(drop=True)
+
+
+def build_single_prediction_summary_lines(scored_row: pd.Series) -> list[str]:
+    return [
+        (
+            f"<strong>Program and school:</strong> "
+            f"{format_feature_value('credential_level', scored_row.get('credential_level'))} "
+            f"at a {format_feature_value('school_type', scored_row.get('school_type'))} school"
+        ),
+        (
+            f"<strong>How hard it is to get in:</strong> "
+            f"{format_feature_value('selectivity_bucket', scored_row.get('selectivity_bucket'))}; "
+            f"admission rate {format_feature_value('admission_rate_overall', scored_row.get('admission_rate_overall'))}"
+        ),
+        (
+            f"<strong>Student background:</strong> "
+            f"{format_feature_value('students_with_pell_grant', scored_row.get('students_with_pell_grant'))} "
+            f"of students receive Pell grants, with median family income "
+            f"{format_feature_value('median_family_income', scored_row.get('median_family_income'))}"
+        ),
+        "<strong>Other details:</strong> Anything not shown here uses a typical Florida default.",
+    ]
+
+
+def build_year_summary_table(selected_row: pd.Series, predictor) -> pd.DataFrame:
+    rows: list[dict[str, str]] = []
+    for year in predictor.years:
+        actual = selected_row.get(f"{year}_year_earning")
+        if pd.isna(actual):
+            actual = selected_row.get(TARGET_COLUMNS[year])
+
+        predicted = selected_row.get(f"{year}_year_pred")
+        if pd.isna(predicted):
+            predicted = selected_row.get(predictor.prediction_columns_by_year[year])
+
+        gap = selected_row.get(f"{year}_year_error")
+        if pd.isna(gap) and pd.notna(actual) and pd.notna(predicted):
+            gap = float(actual) - float(predicted)
+
+        rows.append(
+            {
+                "Time after completion": YEAR_LABELS[year],
+                "Actual": format_currency(actual),
+                "Predicted": format_currency(predicted),
+                "Gap": format_signed_currency(gap),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_demo_examples(frame: pd.DataFrame) -> dict[str, int]:
+    if frame.empty:
+        return {}
+
+    examples: dict[str, int] = {}
+    selections = [
+        ("Recommended: Above expected", frame.nlargest(1, "gap").iloc[0]),
+        ("Recommended: Below expected", frame.nsmallest(1, "gap").iloc[0]),
+    ]
+
+    for prefix, row in selections:
+        label = (
+            f"{prefix} | {row['code']} | "
+            f"{shorten_text(row['title'], 30)} | {shorten_text(row['school_name'], 22)}"
+        )
+        examples[label] = int(row.name)
+
+    return examples
+
+
+def render_program_explorer(programs: pd.DataFrame, actual_programs: pd.DataFrame, predictor) -> None:
+    st.subheader("Program examples")
+    st.markdown(
+        "<div class='section-note'>Search by CIP code, school name, or program title. This tab shows real programs and how their reported earnings compared with the model.</div>",
+        unsafe_allow_html=True,
+    )
+
+    demo_examples = build_demo_examples(actual_programs)
+    demo_choice = st.selectbox(
+        "Quick demo pick",
+        options=["Type my own search"] + list(demo_examples.keys()),
+        index=1 if demo_examples else 0,
+    )
+
+    search = st.text_input(
+        "Search programs",
+        value="",
+        placeholder="Example: 1205, Atlantic Technical, nursing, culinary",
+        disabled=demo_choice != "Type my own search",
+    )
+
+    if demo_choice == "Type my own search":
+        filtered_programs = filter_programs(programs, search)
+    else:
+        filtered_programs = programs.loc[[demo_examples[demo_choice]]].copy()
+        st.caption("Showing a preselected example to keep the demo quick and reliable.")
+
+    st.write(f"Matches found: {len(filtered_programs):,}")
+
+    if filtered_programs.empty:
+        st.warning("No matches found. Try a CIP code, school name, or a few words from the program title.")
+        return
+
+    preview_table = build_results_table(filtered_programs)
+    preview_count = len(preview_table)
+    total_matches = len(filtered_programs)
+    if demo_choice == "Type my own search" and search.strip():
+        st.caption("Best matches appear first.")
+    if total_matches > preview_count:
+        st.caption(f"Showing the first {preview_count} matches.")
+    st.dataframe(preview_table, width="stretch")
+
+    option_ids = filtered_programs.index.tolist()
+    selected_index = 0
+    search_code = "".join(ch for ch in search if ch.isdigit())
+    if search_code:
+        exact_match = filtered_programs[filtered_programs["code"] == search_code.zfill(4)]
+        if len(exact_match) == 1:
+            selected_index = option_ids.index(int(exact_match.index[0]))
+
+    selected_id = st.selectbox(
+        "Choose a program",
+        options=option_ids,
+        index=selected_index,
+        format_func=lambda row_id: build_program_option_label(filtered_programs.loc[row_id]),
+    )
+    selected_row = filtered_programs.loc[selected_id]
+
+    selected_prediction = selected_row[PRIMARY_PREDICTION_COLUMN]
+    selected_actual = selected_row[PRIMARY_ACTUAL_COLUMN]
+    selected_gap = selected_row["gap"]
+    selected_year_table = build_year_summary_table(selected_row, predictor)
+    confidence_text = str(selected_row.get("confidence", "Not available"))
+    median_score_text = (
+        f"{float(selected_row['median_score']):.3f}"
+        if pd.notna(selected_row.get("median_score"))
+        else "Not available"
+    )
+    rank_volatility_text = (
+        f"{float(selected_row['mean_rank_std_pct']):.3f}"
+        if pd.notna(selected_row.get("mean_rank_std_pct"))
+        else "Not available"
+    )
+
+    detail_col, metric_col = st.columns([1.2, 1])
+    with detail_col:
+        st.markdown(
+            f"""
+            <div class="panel">
+                <h3>{selected_row['title']}</h3>
+                <p>
+                    <strong>School:</strong> {selected_row['school_name']}<br>
+                    <strong>CIP code:</strong> {selected_row['code']}<br>
+                    <strong>Award type:</strong> {format_credential_level(selected_row.get('credential_level'))}<br>
+                    <strong>Selectivity group:</strong> {format_feature_value('selectivity_bucket', selected_row.get('selectivity_bucket'))}<br>
+                    <strong>Admission rate:</strong> {format_feature_value('admission_rate_overall', selected_row.get('admission_rate_overall'))}<br>
+                    <strong>Median family income:</strong> {format_feature_value('median_family_income', selected_row.get('median_family_income'))}<br>
+                    <strong>How strong this pattern looks:</strong> {confidence_text}<br>
+                    <strong>Overall multi-year score:</strong> {median_score_text}<br>
+                    <strong>How much the ranking changes across years:</strong> {rank_volatility_text}
+                </p>
+                {status_badge(selected_row['performance'], selected_gap)}
+                <div style="margin-top:0.45rem;">{stability_badge(selected_row['stability_status'])}</div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    with metric_col:
+        metric_a, metric_b, metric_c = st.columns(3)
+        metric_a.metric("Predicted 4-year earnings", format_currency(selected_prediction))
+        metric_b.metric("Actual 4-year earnings", format_currency(selected_actual))
+        metric_c.metric("4-year gap", format_signed_currency(selected_gap))
+
+        if pd.notna(selected_gap):
+            if selected_gap >= 0:
+                st.success(
+                    f"Actual 4-year earnings were {format_signed_currency(selected_gap)} above the model's prediction."
+                )
+            else:
+                st.error(
+                    f"Actual 4-year earnings were {format_signed_currency(selected_gap)} below the model's prediction."
+                )
+        else:
+            st.info("There is no saved 4-year comparison for this program, so only the new prediction is shown.")
+
+    if pd.notna(selected_actual):
+        st.altair_chart(
+            build_program_comparison_chart(float(selected_prediction), float(selected_actual)),
+            width="stretch",
+        )
+
+    st.markdown("**1-, 4-, and 5-year earnings**")
+    st.caption(
+        "These values represent median earnings of graduates who are working and not enrolled, "
+        "measured 1, 4, and 5 years after completion. Each year is a separate snapshot, "
+        "so the numbers do not always increase step by step."
+    )
+    st.dataframe(selected_year_table, width="stretch", hide_index=True)
+    st.caption(
+        "A higher number later on is common, but it is not guaranteed. The 1-, 4-, and 5-year values come from separate reported follow-up periods."
+    )
+
+    with st.expander("See the inputs behind this result", expanded=False):
+        st.dataframe(
+            build_feature_table(selected_row, predictor.feature_columns),
+            width="stretch",
+        )
+
+
+def render_individual_prediction_form(predictor, metadata: dict[str, object], programs: pd.DataFrame) -> None:
+    st.subheader("Estimate earnings for one program")
+    st.markdown(
+        "<div class='section-note'>We kept the main questions on the page so this stays easy to use. If you want, you can open More options and change a few extra details.</div>",
+        unsafe_allow_html=True,
+    )
+
+    st.markdown(
+        """
+        <div class="guide-card">
+            <h3>What you will enter</h3>
+            <p>Program type, award type, school type, how selective the school is, Pell Grant share, and family income.</p>
+            <p>For most quick estimates, that is enough.</p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    template_row = predictor.template_frame(rows=1).iloc[0]
+    feature_options = metadata.get("feature_options", {})
+    profile_options = build_profile_choice_options(programs)
+    cip_reference = build_cip_reference(programs)
+    cip_options = cip_reference["option_label"].tolist()
+    cip_label_to_code = dict(zip(cip_reference["option_label"], cip_reference["code"]))
+    cip_label_to_title = dict(zip(cip_reference["option_label"], cip_reference["sample_title"]))
+    default_cip_code = normalize_code_label(template_row.get("code"))
+    default_cip_label = next(
+        (
+            label
+            for label, code in cip_label_to_code.items()
+            if code == default_cip_code
+        ),
+        cip_options[0],
+    )
+
+    def select_input(label: str, column: str, help_text: str | None = None):
+        options = [normalize_form_value(option) for option in feature_options.get(column, [])]
+        default_value = normalize_form_value(template_row.get(column))
+        if default_value and default_value not in options:
+            options = [default_value] + options
+        if not options:
+            options = [default_value] if default_value else [""]
+        default_index = options.index(default_value) if default_value in options else 0
+        return st.selectbox(
+            label,
+            options=options,
+            index=default_index,
+            format_func=lambda option: get_choice_label(column, option),
+            help=help_text,
+        )
+
+    with st.form("single_prediction_form"):
+        title = st.text_input(
+            "Program name (optional)",
+            value="",
+            placeholder="Example: Registered Nursing",
+        )
+        school_name = st.text_input(
+            "School name (optional)",
+            value="",
+            placeholder="Example: Miami Dade College",
+        )
+        st.markdown("**Program type**")
+        st.caption("Search by program name or CIP code. Try terms like nursing, business, culinary, welding, or 5138.")
+        selected_cip_label = st.selectbox(
+            "Program type",
+            options=cip_options,
+            index=cip_options.index(default_cip_label),
+            help="This searchable list helps match program names to CIP codes.",
+            label_visibility="collapsed",
+        )
+        code = cip_label_to_code[selected_cip_label]
+        st.caption(f"Chosen program: {cip_label_to_title[selected_cip_label]} (CIP {code})")
+
+        input_col_a, input_col_b = st.columns(2)
+        with input_col_a:
+            credential_level = select_input(
+                "Award type",
+                "credential_level",
+                help_text="The type of credential students earn in this program.",
+            )
+            school_type = select_input(
+                "School ownership",
+                "school_type",
+                help_text="Whether the school is public, nonprofit, or for-profit.",
+            )
+            st.markdown("**How selective the school is**")
+            st.caption("Pick the option that feels closest.")
+            selectivity_labels = [option["label"] for option in profile_options["selectivity_bucket"]]
+            selectivity_choice = st.radio(
+                "How selective the school is",
+                options=selectivity_labels,
+                index=option_index_by_value(
+                    profile_options["selectivity_bucket"],
+                    normalize_form_value(template_row.get("selectivity_bucket")),
+                ),
+                horizontal=True,
+                label_visibility="collapsed",
+            )
+            selectivity_bucket = next(
+                option["value"]
+                for option in profile_options["selectivity_bucket"]
+                if option["label"] == selectivity_choice
+            )
+        with input_col_b:
+            st.markdown("**Admission rate**")
+            st.caption("Choose the option that feels closest.")
+            admission_labels = [option["label"] for option in profile_options["admission_rate_overall"]]
+            admission_choice = st.radio(
+                "Admission rate",
+                options=admission_labels,
+                index=closest_numeric_option_index(
+                    profile_options["admission_rate_overall"],
+                    float(template_row.get("admission_rate_overall", 0.0)),
+                ),
+                horizontal=True,
+                label_visibility="collapsed",
+            )
+            admission_rate_overall = next(
+                option["value"]
+                for option in profile_options["admission_rate_overall"]
+                if option["label"] == admission_choice
+            )
+
+            st.markdown("**Pell Grant share**")
+            st.caption("This gives the model a sense of student financial need.")
+            pell_labels = [option["label"] for option in profile_options["students_with_pell_grant"]]
+            pell_choice = st.radio(
+                "Pell Grant share",
+                options=pell_labels,
+                index=closest_numeric_option_index(
+                    profile_options["students_with_pell_grant"],
+                    float(template_row.get("students_with_pell_grant", 0.0)),
+                ),
+                horizontal=True,
+                label_visibility="collapsed",
+            )
+            students_with_pell_grant = next(
+                option["value"]
+                for option in profile_options["students_with_pell_grant"]
+                if option["label"] == pell_choice
+            )
+
+            st.markdown("**Median family income**")
+            st.caption("Pick the option that feels closest.")
+            income_labels = [option["label"] for option in profile_options["median_family_income"]]
+            income_choice = st.radio(
+                "Median family income",
+                options=income_labels,
+                index=closest_numeric_option_index(
+                    profile_options["median_family_income"],
+                    float(template_row.get("median_family_income", 0.0)),
+                ),
+                horizontal=True,
+                label_visibility="collapsed",
+            )
+            median_family_income = next(
+                option["value"]
+                for option in profile_options["median_family_income"]
+                if option["label"] == income_choice
+            )
+
+        with st.expander("More options (optional)", expanded=False):
+            st.caption("Only open this if you want to change a few extra details.")
+            fine_tune_a, fine_tune_b = st.columns(2)
+            with fine_tune_a:
+                age_entry = st.number_input(
+                    "Average age at entry",
+                    min_value=0.0,
+                    value=float(template_row.get("age_entry", 0.0)),
+                    step=0.5,
+                    format="%.1f",
+                    help="Typical age when students start at the institution.",
+                )
+                locale = select_input(
+                    "Community type",
+                    "locale",
+                    help_text="The school's city, suburb, town, or rural setting.",
+                )
+                admission_rate_override = st.number_input(
+                    "Exact admission rate",
+                    min_value=0.0,
+                    max_value=1.0,
+                    value=float(admission_rate_overall),
+                    step=0.01,
+                    format="%.2f",
+                    help="Optional exact override for the preset admissions band.",
+                )
+                pell_override = st.number_input(
+                    "Exact Pell share",
+                    min_value=0.0,
+                    max_value=1.0,
+                    value=float(students_with_pell_grant),
+                    step=0.01,
+                    format="%.2f",
+                    help="Optional exact override for the preset Pell band.",
+                )
+            with fine_tune_b:
+                distance = select_input(
+                    "Online availability",
+                    "distance",
+                    help_text="How fully students can complete the field online.",
+                )
+                income_override = st.number_input(
+                    "Exact median family income",
+                    min_value=0.0,
+                    value=float(median_family_income),
+                    step=1000.0,
+                    format="%.0f",
+                    help="Optional exact override for the preset income band.",
+                )
+                carnegie_size_setting = select_input(
+                    "School size and campus setting",
+                    "carnegie_size_setting",
+                    help_text="A general label for the size of the school and whether students mostly commute or live on campus.",
+                )
+
+        submitted = st.form_submit_button("Estimate earnings", width="stretch")
+
+    if not submitted:
+        return
+
+    admission_rate_overall = admission_rate_override
+    students_with_pell_grant = pell_override
+    median_family_income = income_override
+    carnegie_size_setting = carnegie_size_setting or normalize_form_value(template_row.get("carnegie_size_setting")) or None
+    open_admissions_policy = normalize_form_value(template_row.get("open_admissions_policy")) or None
+    title_iv_eligibility_type = normalize_form_value(template_row.get("title_iv_eligibility_type")) or None
+    location_lat = float(template_row.get("location_lat", 0.0))
+    location_lon = float(template_row.get("location_lon", 0.0))
+
+    record = {
+        "title": title or None,
+        "school_name": school_name or None,
+        "code": code or None,
+        "credential_level": credential_level or None,
+        "school_type": school_type or None,
+        "distance": distance or None,
+        "locale": locale or None,
+        "carnegie_size_setting": carnegie_size_setting or None,
+        "open_admissions_policy": open_admissions_policy or None,
+        "title_iv_eligibility_type": title_iv_eligibility_type or None,
+        "selectivity_bucket": selectivity_bucket or None,
+        "admission_rate_overall": admission_rate_overall,
+        "students_with_pell_grant": students_with_pell_grant,
+        "median_family_income": median_family_income,
+        "age_entry": age_entry,
+        "location_lat": location_lat,
+        "location_lon": location_lon,
+    }
+    scored_single = predictor.predict_frame(pd.DataFrame([record])).iloc[0]
+
+    display_program = title.strip() if title.strip() else cip_label_to_title[selected_cip_label]
+    display_school = school_name.strip() if school_name.strip() else "the school details you entered"
+    summary_lines = "".join(
+        f"<div class='summary-line'>{line}</div>"
+        for line in build_single_prediction_summary_lines(scored_single)
+    )
+
+    st.markdown(
+        f"""
+        <div class="spotlight-card">
+            <div class="spotlight-kicker">Best estimate</div>
+            <div class="spotlight-value">{format_currency(scored_single[predictor.prediction_columns_by_year[4]])}</div>
+            <p>
+                Estimated median earnings about 4 years after finishing <strong>{display_program}</strong>,
+                based on the details entered for <strong>{display_school}</strong>.
+            </p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    render_metric_cards(
+        [
+            {
+                "label": "1 year after completion",
+                "value": format_currency(scored_single[predictor.prediction_columns_by_year[1]]),
+                "note": "Early-career estimate.",
+            },
+            {
+                "label": "4 years after completion",
+                "value": format_currency(scored_single[predictor.prediction_columns_by_year[4]]),
+                "note": "Main number to focus on.",
+            },
+            {
+                "label": "5 years after completion",
+                "value": format_currency(scored_single[predictor.prediction_columns_by_year[5]]),
+                "note": "A later-career estimate.",
+            },
+        ]
+    )
+
+    summary_col, table_col = st.columns([1.05, 0.95])
+    with summary_col:
+        st.markdown(
+            f"""
+            <div class="summary-card">
+                <h3>What we used</h3>
+                {summary_lines}
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+    with table_col:
+        st.markdown("**Estimated earnings over time**")
+        st.dataframe(
+            build_prediction_only_table(scored_single, predictor),
+            width="stretch",
+            hide_index=True,
+        )
+
+    st.caption(
+        "These are model estimates, not actual reported earnings. If you want to compare real programs with the model, open the Real programs tab."
+    )
+
+    with st.expander("See all the details used for this estimate", expanded=False):
+        st.dataframe(
+            build_feature_table(scored_single, predictor.feature_columns),
+            width="stretch",
+            hide_index=True,
+        )
+
+
+def render_individual_predictions_page() -> None:
+    configure_page("Florida Program Earnings | Individual Predictions")
+    predictor, metadata, programs, actual_programs = load_app_state()
+    render_sidebar(metadata, programs)
+    render_hero(
+        "Estimate Program Earnings",
+        "Use the quick form to estimate earnings, or open the Real programs tab to compare actual programs with the model.",
+        ["Quick form", "1-, 4-, and 5-year estimates"],
+    )
+
+    manual_tab, explorer_tab = st.tabs(["Quick estimate", "Examples"])
+    with manual_tab:
+        render_individual_prediction_form(predictor, metadata, programs)
+    with explorer_tab:
+        render_program_explorer(programs, actual_programs, predictor)
+
+
+render_individual_predictions_page()

--- a/src/ira/pages/2_Batch_Predictions.py
+++ b/src/ira/pages/2_Batch_Predictions.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+import streamlit as st
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from ira.streamlit_app import (
+    FEATURE_LABELS,
+    configure_page,
+    format_currency,
+    load_app_state,
+    render_metric_cards,
+    render_sidebar,
+)
+
+
+def inject_batch_compact_styles() -> None:
+    st.markdown(
+        """
+        <style>
+        .block-container {
+            padding-top: 1rem;
+            padding-bottom: 1.2rem;
+        }
+        .hero {
+            padding: 1.1rem 1.25rem;
+            border-radius: 18px;
+            margin-bottom: 0.7rem;
+        }
+        .hero h1 {
+            font-size: 1.8rem;
+            margin-bottom: 0.35rem;
+        }
+        .hero p {
+            font-size: 0.94rem;
+            line-height: 1.45;
+        }
+        .chip-row {
+            margin-top: 0.55rem;
+        }
+        .chip {
+            padding: 0.32rem 0.62rem;
+            margin-bottom: 0.25rem;
+            font-size: 0.8rem;
+        }
+        .metric-card,
+        .panel,
+        .guide-card,
+        .summary-card,
+        .spotlight-card {
+            padding: 0.9rem 1rem;
+            margin-bottom: 0.55rem;
+            border-radius: 16px;
+        }
+        .metric-card {
+            min-height: 92px;
+        }
+        .metric-label {
+            font-size: 0.82rem;
+            margin-bottom: 0.2rem;
+        }
+        .metric-value {
+            font-size: 1.45rem;
+        }
+        .metric-note,
+        .guide-card p,
+        .summary-card p,
+        .panel p {
+            font-size: 0.9rem;
+            line-height: 1.42;
+        }
+        .guide-card h3,
+        .summary-card h3,
+        .spotlight-card h3,
+        .panel h3 {
+            font-size: 1rem;
+            margin-bottom: 0.35rem;
+        }
+        .spotlight-value {
+            font-size: 2rem;
+            margin-bottom: 0.2rem;
+        }
+        .section-note {
+            margin-bottom: 0.55rem;
+            font-size: 0.9rem;
+        }
+        div[data-testid="stFileUploader"] {
+            margin-bottom: 0.45rem;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def build_required_columns_table(predictor) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Required column": predictor.feature_columns,
+            "What it means": [FEATURE_LABELS.get(column, column) for column in predictor.feature_columns],
+        }
+    )
+
+
+def build_batch_preview_table(scored_batch: pd.DataFrame, predictor) -> pd.DataFrame:
+    preview_columns = [
+        column
+        for column in [
+            "code",
+            "title",
+            "school_name",
+            "credential_level",
+            predictor.prediction_columns_by_year[1],
+            predictor.prediction_columns_by_year[4],
+            predictor.prediction_columns_by_year[5],
+        ]
+        if column in scored_batch.columns
+    ]
+
+    preview_frame = scored_batch[preview_columns].head(5).copy().rename(
+        columns={
+            "code": "CIP",
+            "title": "Program",
+            "school_name": "School",
+            "credential_level": "Award type",
+            predictor.prediction_columns_by_year[1]: "Predicted 1-year earnings",
+            predictor.prediction_columns_by_year[4]: "Predicted 4-year earnings",
+            predictor.prediction_columns_by_year[5]: "Predicted 5-year earnings",
+        }
+    )
+
+    for column in [
+        "Predicted 1-year earnings",
+        "Predicted 4-year earnings",
+        "Predicted 5-year earnings",
+    ]:
+        if column in preview_frame.columns:
+            preview_frame[column] = preview_frame[column].map(format_currency)
+
+    return preview_frame
+
+
+def render_batch_prediction_workspace(predictor) -> None:
+    info_col, stats_col = st.columns([1.25, 1])
+    with info_col:
+        st.markdown(
+            """
+            <div class="guide-card">
+                <h3>Quick flow</h3>
+                <p>Download the template, fill one row per program, upload the file, and download the scored CSV.</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+    with stats_col:
+        render_metric_cards(
+            [
+                {
+                    "label": "Required fields",
+                    "value": f"{len(predictor.feature_columns)}",
+                    "note": "Use the template columns as-is.",
+                },
+                {
+                    "label": "Predictions",
+                    "value": "1, 4, 5",
+                    "note": "Years added to each row.",
+                },
+            ]
+        )
+
+    batch_left, batch_right = st.columns([0.92, 1.08], gap="large")
+    template_df = predictor.template_frame(rows=25)
+    required_columns_table = build_required_columns_table(predictor)
+
+    with batch_left:
+        st.markdown(
+            """
+            <div class="panel">
+                <h3>Step 1: Download the template</h3>
+                <p>Start here so your file has the right columns.</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.download_button(
+            "Download template CSV",
+            data=template_df.to_csv(index=False).encode("utf-8"),
+            file_name="sample_program_input.csv",
+            mime="text/csv",
+            width="stretch",
+        )
+        st.markdown(
+            """
+            <div class="summary-card">
+                <h3>Checklist</h3>
+                <p>One row = one program.</p>
+                <p>Keep the same column names.</p>
+                <p>Extra columns can stay.</p>
+                <p>The template includes 25 sample rows, so the results preview only shows part of the file.</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+        with st.expander("Columns the model needs", expanded=False):
+            st.dataframe(
+                required_columns_table,
+                width="stretch",
+                hide_index=True,
+                height=240,
+            )
+        with st.expander("Preview the template", expanded=False):
+            st.dataframe(template_df.head(4), width="stretch", hide_index=True, height=180)
+
+    with batch_right:
+        st.markdown(
+            """
+            <div class="panel">
+                <h3>Step 2: Upload your file</h3>
+                <p>Upload the CSV and the app will score every row.</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        uploaded_file = st.file_uploader(
+            "Upload a CSV",
+            type=["csv"],
+            help="The easiest path is to fill in the template and upload it here.",
+        )
+
+        if uploaded_file is None:
+            st.markdown(
+                """
+                <div class="summary-card">
+                    <h3>Output</h3>
+                    <p>Your original file stays the same, and the app adds predicted 1-, 4-, and 5-year earnings.</p>
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+            return
+
+        try:
+            batch = pd.read_csv(uploaded_file)
+        except Exception as exc:
+            st.error("We could not read that file as a CSV.")
+            st.caption(str(exc))
+            return
+
+        missing_columns = [column for column in predictor.feature_columns if column not in batch.columns]
+
+        if missing_columns:
+            st.error("Your file is missing required columns.")
+            st.dataframe(
+                required_columns_table[required_columns_table["Required column"].isin(missing_columns)],
+                width="stretch",
+                hide_index=True,
+                height=220,
+            )
+            st.caption("Download the template and keep the same column names. Extra columns are okay.")
+            return
+
+        scored_batch = predictor.predict_frame(batch)
+        preview_frame = build_batch_preview_table(scored_batch, predictor)
+        summary_left, summary_right = st.columns([1.2, 0.8])
+        with summary_left:
+            st.success(f"Done. {len(scored_batch):,} rows were scored.")
+        with summary_right:
+            st.download_button(
+                "Download scored CSV",
+                data=scored_batch.to_csv(index=False).encode("utf-8"),
+                file_name="predictions.csv",
+                mime="text/csv",
+                width="stretch",
+            )
+
+        st.markdown(
+            f"""
+            <div class="summary-card">
+                <h3>Preview</h3>
+                <p>Showing the first 5 rows only. The download includes all <strong>{len(scored_batch):,}</strong> rows.</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.dataframe(preview_frame, width="stretch", hide_index=True, height=260)
+        st.download_button(
+            "Download template again",
+            data=template_df.to_csv(index=False).encode("utf-8"),
+            file_name="sample_program_input.csv",
+            mime="text/csv",
+            width="stretch",
+        )
+
+
+def render_batch_predictions_page() -> None:
+    configure_page("Florida Program Earnings | Batch Predictions")
+    inject_batch_compact_styles()
+    predictor, metadata, programs, _ = load_app_state()
+    render_sidebar(metadata, programs)
+    st.markdown(
+        """
+        <div class="hero">
+            <h1>Batch Predictions</h1>
+            <p>Upload one CSV, score every row, and download the finished file with predicted 1-, 4-, and 5-year earnings.</p>
+            <div class="chip-row">
+                <span class="chip">CSV upload</span>
+                <span class="chip">Template download</span>
+                <span class="chip">Bulk scoring</span>
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+    render_batch_prediction_workspace(predictor)
+
+
+render_batch_predictions_page()

--- a/src/ira/streamlit_app.py
+++ b/src/ira/streamlit_app.py
@@ -31,21 +31,86 @@ YEAR_LABELS = {
 }
 
 FEATURE_LABELS = {
-    "code": "CIP code",
-    "distance": "Distance learning code",
-    "school_type": "School type",
-    "credential_level": "Credential level",
-    "locale": "Locale code",
-    "carnegie_size_setting": "Carnegie size and setting",
-    "open_admissions_policy": "Open admissions policy",
-    "title_iv_eligibility_type": "Title IV eligibility",
-    "selectivity_bucket": "Selectivity group",
+    "code": "Program CIP code",
+    "distance": "Online availability",
+    "school_type": "School ownership",
+    "credential_level": "Award type",
+    "locale": "Community type",
+    "carnegie_size_setting": "School size and campus setting",
+    "open_admissions_policy": "Open admissions",
+    "title_iv_eligibility_type": "Federal aid category",
+    "selectivity_bucket": "Admissions selectivity",
     "admission_rate_overall": "Admission rate",
     "location_lat": "Latitude",
     "location_lon": "Longitude",
     "median_family_income": "Median family income",
-    "students_with_pell_grant": "Students with Pell grant",
+    "students_with_pell_grant": "Students receiving Pell grants",
     "age_entry": "Average age at entry",
+}
+
+VALUE_LABELS = {
+    "distance": {
+        "0": "Not reported to IPEDS",
+        "1": "No credential in this field can be completed fully online",
+        "2": "Some credentials in this field can be completed fully online",
+        "3": "All credentials in this field can be completed fully online",
+    },
+    "locale": {
+        "11": "City: Large",
+        "12": "City: Midsize",
+        "13": "City: Small",
+        "21": "Suburb: Large",
+        "22": "Suburb: Midsize",
+        "23": "Suburb: Small",
+        "31": "Town: Fringe",
+        "32": "Town: Distant",
+        "33": "Town: Remote",
+        "41": "Rural: Fringe",
+        "42": "Rural: Distant",
+        "43": "Rural: Remote",
+    },
+    "carnegie_size_setting": {
+        "-2": "Not applicable",
+        "0": "Not classified",
+        "1": "Two-year, very small",
+        "2": "Two-year, small",
+        "3": "Two-year, medium",
+        "4": "Two-year, large",
+        "5": "Two-year, very large",
+        "6": "Four-year, very small, primarily nonresidential",
+        "7": "Four-year, very small, primarily residential",
+        "8": "Four-year, very small, highly residential",
+        "9": "Four-year, small, primarily nonresidential",
+        "10": "Four-year, small, primarily residential",
+        "11": "Four-year, small, highly residential",
+        "12": "Four-year, medium, primarily nonresidential",
+        "13": "Four-year, medium, primarily residential",
+        "14": "Four-year, medium, highly residential",
+        "15": "Four-year, large, primarily nonresidential",
+        "16": "Four-year, large, primarily residential",
+        "17": "Four-year, large, highly residential",
+        "18": "Exclusively graduate or professional",
+    },
+    "open_admissions_policy": {
+        "1": "Yes",
+        "2": "No",
+        "3": "Does not enroll first-time students",
+    },
+    "title_iv_eligibility_type": {
+        "1": "Participates in federal Title IV aid programs",
+        "2": "Branch campus of a Title IV participating institution",
+        "3": "Limited Title IV participation",
+        "5": "Not currently participating, but has an OPE ID",
+        "6": "Not currently participating and has no OPE ID",
+        "7": "Stopped participating during the collection year",
+        "8": "Became eligible during the collection year",
+        "19": "Not eligible",
+    },
+    "selectivity_bucket": {
+        "elite": "More selective admissions",
+        "mid": "Moderately selective admissions",
+        "open": "Broad-access admissions",
+    },
 }
 
 
@@ -95,6 +160,26 @@ def load_scored_programs(data_path: str, _predictor) -> pd.DataFrame:
     )
     scored["stability_status"] = scored["stability_status"].fillna("No multi-year signal")
     return scored.sort_values(["school_name", "title"]).reset_index(drop=True)
+
+
+def configure_page(page_title: str) -> None:
+    st.set_page_config(
+        page_title=page_title,
+        layout="wide",
+        initial_sidebar_state="expanded",
+    )
+    inject_styles()
+
+
+def load_app_state():
+    predictor = get_predictor()
+    metadata = predictor.metadata()
+    metadata["evaluation_table"] = predictor.evaluation_table().rename(
+        columns={"R2 (log scale)": "R^2 (log scale)"}
+    )
+    programs = load_scored_programs(str(DATA_PATH), predictor)
+    actual_programs = programs.dropna(subset=["gap"]).copy()
+    return predictor, metadata, programs, actual_programs
 
 
 def normalize_search_text(value: object) -> str:
@@ -158,6 +243,15 @@ def format_feature_value(column: str, value: object) -> str:
         return "Not available"
     if column == "credential_level":
         return format_credential_level(value)
+    if column in {
+        "distance",
+        "locale",
+        "carnegie_size_setting",
+        "open_admissions_policy",
+        "title_iv_eligibility_type",
+        "selectivity_bucket",
+    }:
+        return get_value_label(column, value)
     if column in {"admission_rate_overall", "students_with_pell_grant"}:
         return format_percent(value)
     if column == "median_family_income":
@@ -174,22 +268,52 @@ def shorten_text(value: object, limit: int = 36) -> str:
     return text[: limit - 3].rstrip() + "..."
 
 
+def normalize_form_value(value: object, fallback: str = "") -> str:
+    if pd.isna(value):
+        return fallback
+    return str(value)
+
+
+def normalize_code_label(value: object, fallback: str = "") -> str:
+    text = normalize_form_value(value, fallback=fallback).strip()
+    if re.fullmatch(r"-?\d+\.0", text):
+        return text[:-2]
+    return text
+
+
+def get_value_label(column: str, value: object) -> str:
+    normalized = normalize_code_label(value)
+    label = VALUE_LABELS.get(column, {}).get(normalized)
+    if label:
+        return label
+    return normalize_form_value(value, fallback="Not available")
+
+
+def get_choice_label(column: str, value: object) -> str:
+    if column == "credential_level":
+        return format_credential_level(value)
+    return format_feature_value(column, value)
+
+
+def render_hero(title: str, description: str, chips: list[str]) -> None:
+    chip_html = "".join(f"<span class='chip'>{chip}</span>" for chip in chips)
+    st.markdown(
+        f"""
+        <div class="hero">
+            <h1>{title}</h1>
+            <p>{description}</p>
+            <div class="chip-row">{chip_html}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
 def build_chart_label(row: pd.Series) -> str:
     return (
         f"{row['code']} | "
         f"{shorten_text(row['title'], 28)} | "
         f"{shorten_text(row['school_name'], 20)}"
-    )
-
-
-def build_program_option_label(row: pd.Series) -> str:
-    actual_text = format_currency(row.get(PRIMARY_ACTUAL_COLUMN, row.get("4_yr_median_earnings")))
-    gap_text = format_signed_currency(row.get("gap"))
-    return (
-        f"{row['code']} | "
-        f"{shorten_text(row['title'], 50)} | "
-        f"{shorten_text(row['school_name'], 30)} | "
-        f"Actual: {actual_text} | Gap: {gap_text}"
     )
 
 
@@ -337,6 +461,61 @@ def inject_styles() -> None:
             margin-top: -0.2rem;
             margin-bottom: 0.9rem;
         }
+        .guide-card,
+        .spotlight-card,
+        .summary-card {
+            background: linear-gradient(180deg, rgba(18, 30, 46, 0.98) 0%, rgba(14, 24, 38, 0.98) 100%);
+            border: 1px solid var(--border);
+            border-radius: 20px;
+            box-shadow: 0 14px 32px rgba(0, 0, 0, 0.22);
+            padding: 1.2rem 1.3rem;
+            margin-bottom: 0.9rem;
+        }
+        .guide-card h3,
+        .spotlight-card h3,
+        .summary-card h3 {
+            color: var(--primary);
+            margin: 0 0 0.55rem 0;
+            font-size: 1.1rem;
+            font-weight: 800;
+        }
+        .guide-card p,
+        .summary-card p {
+            color: var(--text);
+            line-height: 1.6;
+            margin: 0.35rem 0;
+            font-size: 0.97rem;
+        }
+        .spotlight-kicker {
+            color: var(--secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 0.78rem;
+            font-weight: 700;
+            margin-bottom: 0.45rem;
+        }
+        .spotlight-value {
+            color: var(--highlight);
+            font-size: 2.6rem;
+            line-height: 1.05;
+            font-weight: 900;
+            margin-bottom: 0.4rem;
+            text-shadow: 0 0 18px rgba(243, 182, 76, 0.12);
+        }
+        .spotlight-card p {
+            color: #dbe7f5;
+            line-height: 1.6;
+            margin: 0;
+        }
+        .summary-line {
+            color: var(--text);
+            line-height: 1.55;
+            margin: 0.42rem 0;
+            font-size: 0.97rem;
+        }
+        .summary-line strong {
+            color: var(--primary);
+        }
         [data-testid="stSidebar"] {
             background: rgba(12, 21, 32, 0.98);
             border-left: 1px solid var(--border);
@@ -370,6 +549,28 @@ def inject_styles() -> None:
             background: #20405d;
             border-color: #3f6c92;
             color: white;
+        }
+        .stRadio [role="radiogroup"] {
+            gap: 0.55rem;
+            display: flex;
+            flex-wrap: wrap;
+        }
+        .stRadio [role="radiogroup"] label {
+            background: rgba(20, 33, 50, 0.96);
+            border: 1px solid var(--border);
+            border-radius: 14px;
+            padding: 0.5rem 0.85rem;
+            min-height: 2.9rem;
+            transition: all 0.18s ease;
+        }
+        .stRadio [role="radiogroup"] label:hover {
+            border-color: #3f6c92;
+            background: #17324b;
+        }
+        .stRadio [role="radiogroup"] label:has(input:checked) {
+            background: linear-gradient(180deg, #17324b 0%, #20425f 100%);
+            border-color: #4d7aa3;
+            box-shadow: 0 0 0 1px rgba(127, 183, 216, 0.16);
         }
         div[data-testid="stMetricValue"] {
             color: var(--highlight);
@@ -715,93 +916,15 @@ def build_highlight_table(frame: pd.DataFrame, ascending: bool) -> pd.DataFrame:
     )
 
 
-def build_results_table(frame: pd.DataFrame, max_rows: int = 12) -> pd.DataFrame:
-    preview = frame.copy()
-    if "match_score" in preview.columns:
-        preview = preview.head(max_rows)
-    else:
-        preview["sort_gap"] = preview["gap"].abs().fillna(-1)
-        preview = preview.sort_values(["sort_gap", "title"], ascending=[False, True]).head(max_rows)
-    return pd.DataFrame(
-        {
-            "CIP": preview["code"],
-            "Program": preview["title"],
-            "School": preview["school_name"],
-            "Actual": preview[PRIMARY_ACTUAL_COLUMN].map(format_currency),
-            "Predicted": preview[PRIMARY_PREDICTION_COLUMN].map(format_currency),
-            "Gap vs expected": preview["gap"].map(format_signed_currency),
-            "Compared with expected": preview["performance"],
-            "Multi-year pattern": preview["stability_status"],
-        }
-    )
-
-
-def build_feature_table(selected_row: pd.Series, feature_columns: list[str]) -> pd.DataFrame:
-    return pd.DataFrame(
-        {
-            "Feature": [FEATURE_LABELS.get(column, column) for column in feature_columns],
-            "Value": [format_feature_value(column, selected_row.get(column)) for column in feature_columns],
-        }
-    )
-
-
-def build_year_summary_table(selected_row: pd.Series, predictor) -> pd.DataFrame:
-    rows: list[dict[str, str]] = []
-    for year in predictor.years:
-        actual = selected_row.get(f"{year}_year_earning")
-        if pd.isna(actual):
-            actual = selected_row.get(TARGET_COLUMNS[year])
-
-        predicted = selected_row.get(f"{year}_year_pred")
-        if pd.isna(predicted):
-            predicted = selected_row.get(predictor.prediction_columns_by_year[year])
-
-        gap = selected_row.get(f"{year}_year_error")
-        if pd.isna(gap) and pd.notna(actual) and pd.notna(predicted):
-            gap = float(actual) - float(predicted)
-
-        rows.append(
-            {
-                "Time after completion": YEAR_LABELS[year],
-                "Actual": format_currency(actual),
-                "Predicted": format_currency(predicted),
-                "Gap": format_signed_currency(gap),
-            }
-        )
-
-    return pd.DataFrame(rows)
-
-
-def build_demo_examples(frame: pd.DataFrame) -> dict[str, int]:
-    if frame.empty:
-        return {}
-
-    examples: dict[str, int] = {}
-
-    selections = [
-        ("Recommended: Above expected", frame.nlargest(1, "gap").iloc[0]),
-        ("Recommended: Below expected", frame.nsmallest(1, "gap").iloc[0]),
-    ]
-
-    for prefix, row in selections:
-        label = (
-            f"{prefix} | {row['code']} | "
-            f"{shorten_text(row['title'], 30)} | {shorten_text(row['school_name'], 22)}"
-        )
-        examples[label] = int(row.name)
-
-    return examples
-
-
 def render_sidebar(metadata: dict[str, object], scored_programs: pd.DataFrame) -> None:
     metrics = metadata["metrics"]
     actual_programs = scored_programs[PRIMARY_ACTUAL_COLUMN].notna().sum()
     stable_programs = scored_programs["median_score"].notna().sum()
     friendly_feature_labels = [FEATURE_LABELS.get(column, column) for column in metadata["feature_columns"]]
 
-    st.sidebar.title("About this dashboard")
+    st.sidebar.title("About this app")
     st.sidebar.write(
-        "This dashboard predicts Florida program earnings and shows which programs are above or below expected earnings across 1, 4, and 5 years."
+        "Use the page list above to switch between the dashboard, an individual prediction form, and batch scoring."
     )
     st.sidebar.metric("4-year model fit (R^2, log scale)", f"{metrics['r2_log']:.3f}")
     st.sidebar.metric("Typical 4-year error", format_currency(metrics["mae"]))
@@ -813,24 +936,12 @@ def render_sidebar(metadata: dict[str, object], scored_programs: pd.DataFrame) -
     with st.sidebar.expander("What the model uses", expanded=False):
         st.write(", ".join(friendly_feature_labels))
     with st.sidebar.expander("Model results by year", expanded=False):
-        st.dataframe(metadata["evaluation_table"], use_container_width=True, hide_index=True)
+        st.dataframe(metadata["evaluation_table"], width="stretch", hide_index=True)
 
 
 def render_dashboard() -> None:
-    st.set_page_config(
-        page_title="Florida Program Earnings Dashboard",
-        layout="wide",
-        initial_sidebar_state="expanded",
-    )
-
-    inject_styles()
-    predictor = get_predictor()
-    metadata = predictor.metadata()
-    metadata["evaluation_table"] = predictor.evaluation_table().rename(
-        columns={"R2 (log scale)": "R^2 (log scale)"}
-    )
-    programs = load_scored_programs(str(DATA_PATH), predictor)
-    actual_programs = programs.dropna(subset=["gap"]).copy()
+    configure_page("Florida Program Earnings Dashboard")
+    _, metadata, programs, actual_programs = load_app_state()
 
     total_programs = len(programs)
     total_schools = programs["school_name"].nunique()
@@ -843,23 +954,10 @@ def render_dashboard() -> None:
 
     render_sidebar(metadata, programs)
 
-    st.markdown(
-        """
-        <div class="hero">
-            <h1>Florida Program Earnings Dashboard</h1>
-            <p>
-                Compare Florida programs' reported earnings with what the model expected. Search by school
-                or program, review the 1-, 4-, and 5-year results, and upload a CSV to score new rows.
-            </p>
-            <div class="chip-row">
-                <span class="chip">XGBoost model</span>
-                <span class="chip">1-, 4-, and 5-year view</span>
-                <span class="chip">Program search</span>
-                <span class="chip">Batch upload</span>
-            </div>
-        </div>
-        """,
-        unsafe_allow_html=True,
+    render_hero(
+        "Florida Program Earnings Dashboard",
+        "Compare Florida programs' reported earnings with what the model expected, then use the sidebar pages for individual or batch predictions.",
+        ["XGBoost model", "Statewide comparison", "Individual predictions", "Batch predictions"],
     )
 
     render_metric_cards(
@@ -910,7 +1008,7 @@ def render_dashboard() -> None:
             "<div class='section-note'>Each dot is one program at one school. Dots above the dashed line had higher actual 4-year earnings than the model expected.</div>",
             unsafe_allow_html=True,
         )
-        st.altair_chart(build_scatter_chart(actual_programs, PRIMARY_PREDICTION_COLUMN), use_container_width=True)
+        st.altair_chart(build_scatter_chart(actual_programs, PRIMARY_PREDICTION_COLUMN), width="stretch")
 
     st.subheader("Programs with the largest gaps")
     st.markdown(
@@ -931,7 +1029,7 @@ def render_dashboard() -> None:
     st.markdown("**Programs most above expected**")
     st.dataframe(
         build_highlight_table(actual_programs, ascending=False),
-        use_container_width=True,
+        width="stretch",
         hide_index=True,
         column_config=highlight_column_config,
         height=216,
@@ -940,244 +1038,14 @@ def render_dashboard() -> None:
     st.markdown("**Programs most below expected**")
     st.dataframe(
         build_highlight_table(actual_programs, ascending=True),
-        use_container_width=True,
+        width="stretch",
         hide_index=True,
         column_config=highlight_column_config,
         height=216,
     )
 
     st.caption("This chart shows the biggest positive and negative gaps in one place.")
-    st.altair_chart(build_extreme_gap_chart(actual_programs), use_container_width=True)
-
-    explore_tab, batch_tab = st.tabs(["Explore programs", "Batch upload"])
-
-    with explore_tab:
-        st.subheader("Find a program")
-        st.markdown(
-            "<div class='section-note'>Search by CIP code, school name, or program title. For the presentation, the simplest flow is: search, pick a match, and explain the gap.</div>",
-            unsafe_allow_html=True,
-        )
-
-        demo_examples = build_demo_examples(actual_programs)
-        demo_choice = st.selectbox(
-            "Quick demo pick",
-            options=["Type my own search"] + list(demo_examples.keys()),
-            index=1 if demo_examples else 0,
-        )
-
-        search = st.text_input(
-            "Search programs",
-            value="",
-            placeholder="Example: 1205, Atlantic Technical, nursing, culinary",
-            disabled=demo_choice != "Type my own search",
-        )
-
-        if demo_choice == "Type my own search":
-            filtered_programs = filter_programs(programs, search)
-        else:
-            filtered_programs = programs.loc[[demo_examples[demo_choice]]].copy()
-            st.caption("Showing a preselected example to keep the demo quick and reliable.")
-
-        st.write(f"Matches found: {len(filtered_programs):,}")
-
-        if filtered_programs.empty:
-            st.warning("No matches found. Try a CIP code, school name, or a few words from the program title.")
-        else:
-            preview_table = build_results_table(filtered_programs)
-            preview_count = len(preview_table)
-            total_matches = len(filtered_programs)
-            if demo_choice == "Type my own search" and search.strip():
-                st.caption("Best matches appear first.")
-            if total_matches > preview_count:
-                st.caption(f"Showing the first {preview_count} matches.")
-            st.dataframe(preview_table, use_container_width=True)
-
-            option_ids = filtered_programs.index.tolist()
-            selected_index = 0
-            search_code = "".join(ch for ch in search if ch.isdigit())
-            if search_code:
-                exact_match = filtered_programs[filtered_programs["code"] == search_code.zfill(4)]
-                if len(exact_match) == 1:
-                    selected_index = option_ids.index(int(exact_match.index[0]))
-
-            selected_id = st.selectbox(
-                "Choose a program",
-                options=option_ids,
-                index=selected_index,
-                format_func=lambda row_id: build_program_option_label(filtered_programs.loc[row_id]),
-            )
-            selected_row = filtered_programs.loc[selected_id]
-
-            selected_prediction = selected_row[PRIMARY_PREDICTION_COLUMN]
-            selected_actual = selected_row[PRIMARY_ACTUAL_COLUMN]
-            selected_gap = selected_row["gap"]
-            selected_year_table = build_year_summary_table(selected_row, predictor)
-            confidence_text = str(selected_row.get("confidence", "Not available"))
-            median_score_text = (
-                f"{float(selected_row['median_score']):.3f}"
-                if pd.notna(selected_row.get("median_score"))
-                else "Not available"
-            )
-            rank_volatility_text = (
-                f"{float(selected_row['mean_rank_std_pct']):.3f}"
-                if pd.notna(selected_row.get("mean_rank_std_pct"))
-                else "Not available"
-            )
-
-            detail_col, metric_col = st.columns([1.2, 1])
-            with detail_col:
-                st.markdown(
-                    f"""
-                    <div class="panel">
-                        <h3>{selected_row['title']}</h3>
-                        <p>
-                            <strong>School:</strong> {selected_row['school_name']}<br>
-                            <strong>CIP code:</strong> {selected_row['code']}<br>
-                            <strong>Award type:</strong> {format_credential_level(selected_row.get('credential_level'))}<br>
-                            <strong>Selectivity group:</strong> {format_feature_value('selectivity_bucket', selected_row.get('selectivity_bucket'))}<br>
-                            <strong>Admission rate:</strong> {format_feature_value('admission_rate_overall', selected_row.get('admission_rate_overall'))}<br>
-                            <strong>Median family income:</strong> {format_feature_value('median_family_income', selected_row.get('median_family_income'))}<br>
-                            <strong>How strong this pattern looks:</strong> {confidence_text}<br>
-                            <strong>Overall multi-year score:</strong> {median_score_text}<br>
-                            <strong>How much the ranking changes across years:</strong> {rank_volatility_text}
-                        </p>
-                        {status_badge(selected_row['performance'], selected_gap)}
-                        <div style="margin-top:0.45rem;">{stability_badge(selected_row['stability_status'])}</div>
-                    </div>
-                    """,
-                    unsafe_allow_html=True,
-                )
-
-            with metric_col:
-                metric_a, metric_b, metric_c = st.columns(3)
-                metric_a.metric("Predicted 4-year earnings", format_currency(selected_prediction))
-                metric_b.metric("Actual 4-year earnings", format_currency(selected_actual))
-                metric_c.metric("4-year gap", format_signed_currency(selected_gap))
-
-                if pd.notna(selected_gap):
-                    if selected_gap >= 0:
-                        st.success(
-                            f"Actual 4-year earnings were {format_signed_currency(selected_gap)} above the model's prediction."
-                        )
-                    else:
-                        st.error(
-                            f"Actual 4-year earnings were {format_signed_currency(selected_gap)} below the model's prediction."
-                        )
-                else:
-                    st.info("There is no saved 4-year comparison for this program, so only the new prediction is shown.")
-
-            if pd.notna(selected_actual):
-                st.altair_chart(
-                    build_program_comparison_chart(float(selected_prediction), float(selected_actual)),
-                    use_container_width=True,
-                )
-
-            st.markdown("**1-, 4-, and 5-year earnings**")
-            st.caption(
-                "These values represent median earnings of graduates who are working and not enrolled, "
-                "measured 1, 4, and 5 years after completion. Each year is a separate snapshot, "
-                "so the numbers do not always increase step by step."
-            )
-            st.dataframe(selected_year_table, use_container_width=True, hide_index=True)
-            st.caption(
-                "A higher number later on is common, but it is not guaranteed. The 1-, 4-, and 5-year values come from separate reported follow-up periods."
-            )
-
-            with st.expander("What the model used for this prediction", expanded=False):
-                st.dataframe(
-                    build_feature_table(selected_row, predictor.feature_columns),
-                    use_container_width=True,
-                )
-
-    with batch_tab:
-        st.subheader("Upload a file to score programs")
-        st.markdown(
-            "<div class='section-note'>Use this during the presentation: download the template, upload a CSV, and then download the results.</div>",
-            unsafe_allow_html=True,
-        )
-
-        batch_left, batch_right = st.columns([1, 1.2])
-        template_df = programs[predictor.feature_columns].head(10).copy()
-
-        with batch_left:
-            st.markdown(
-                """
-                <div class="panel">
-                    <h3>Step 1: Download the template</h3>
-                    <p>This sample file already has the columns the model needs, in the right order.</p>
-                </div>
-                """,
-                unsafe_allow_html=True,
-            )
-            st.download_button(
-                "Download template CSV",
-                data=template_df.to_csv(index=False).encode("utf-8"),
-                file_name="sample_program_input.csv",
-                mime="text/csv",
-            )
-
-            with st.expander("Columns the model needs", expanded=False):
-                st.dataframe(
-                    pd.DataFrame({"Required column": predictor.feature_columns}),
-                    use_container_width=True,
-                )
-
-        with batch_right:
-            st.markdown(
-                """
-                <div class="panel">
-                    <h3>Step 2: Upload your file</h3>
-                    <p>Upload a CSV with those columns. The app will preview the predictions and let you download the full scored file.</p>
-                </div>
-                """,
-                unsafe_allow_html=True,
-            )
-            uploaded_file = st.file_uploader("Upload a CSV", type=["csv"])
-
-            if uploaded_file is not None:
-                batch = pd.read_csv(uploaded_file)
-                missing_columns = [column for column in predictor.feature_columns if column not in batch.columns]
-
-                if missing_columns:
-                    st.error(f"Your file is missing these columns: {', '.join(missing_columns)}")
-                else:
-                    scored_batch = predictor.predict_frame(batch)
-                    preview_columns = [
-                        column
-                        for column in [
-                            "code",
-                            "title",
-                            "school_name",
-                            "credential_level",
-                            predictor.prediction_columns_by_year[1],
-                            predictor.prediction_columns_by_year[4],
-                            predictor.prediction_columns_by_year[5],
-                        ]
-                        if column in scored_batch.columns
-                    ]
-                    preview_frame = scored_batch[preview_columns].head(10).rename(
-                        columns={
-                            "code": "CIP",
-                            "title": "Program",
-                            "school_name": "School",
-                            "credential_level": "Credential level",
-                            predictor.prediction_columns_by_year[1]: "Predicted 1-year earnings",
-                            predictor.prediction_columns_by_year[4]: "Predicted 4-year earnings",
-                            predictor.prediction_columns_by_year[5]: "Predicted 5-year earnings",
-                        }
-                    )
-
-                    preview_a, preview_b = st.columns(2)
-                    preview_a.metric("Rows scored", f"{len(scored_batch):,}")
-                    preview_b.metric("Predictions returned", "1-, 4-, and 5-year earnings")
-
-                    st.dataframe(preview_frame, use_container_width=True)
-                    st.download_button(
-                        "Download scored CSV",
-                        data=scored_batch.to_csv(index=False).encode("utf-8"),
-                        file_name="predictions.csv",
-                        mime="text/csv",
-                    )
+    st.altair_chart(build_extreme_gap_chart(actual_programs), width="stretch")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR separates the prediction workflows in the Streamlit app into two dedicated pages: one for individual predictions and one for batch predictions.

## Changes
- moved individual prediction functionality into `1_Individual_Predictions.py`
- moved batch prediction functionality into `2_Batch_Predictions.py`
- updated `streamlit_app.py` so the app routes these workflows as separate pages
- updated the README to reflect the new page structure

## Why
Splitting these into separate pages makes the app easier to navigate and keeps the single-record and CSV batch workflows more organized for users.